### PR TITLE
Update ZWD mapping for perm-group-II alignment

### DIFF
--- a/zwd2rnacentral.py
+++ b/zwd2rnacentral.py
@@ -106,6 +106,7 @@ def get_folders():
         # 'hairpin',
         # 'patches',
         'preQ1-III',
+        "perm-group-II",
         'r-leader',
         'ts',
         'twister',
@@ -184,7 +185,7 @@ def main():
     data = {
         'data': entries,
         'metaData': {
-                "dateProduced": "2020-06-05T00:00:00+01:00",
+                "dateProduced": "2025-04-01T00:00:00+01:00",
                 'dataProvider': 'ZWD',
                 'release': '1.1',
                 'schemaVersion': '0.2.0',


### PR DESCRIPTION
Should update the json file we import to use the latest versions of the data in ZWD

Passes validation with a few warnings about sequence uncertainty

Note: I don't checkout a specific commit of ZWD, only using the latest one as of 01-04-2025

